### PR TITLE
Site will display first location by default

### DIFF
--- a/src/components/locations/LocationPage.tsx
+++ b/src/components/locations/LocationPage.tsx
@@ -60,16 +60,6 @@ class LocationPage extends React.Component<ILocationPageProps> {
                 }
             });
         }
-        // Find the location where arrival/departure is around current date
-        if (!this.state.selectedLocation) {
-            // Find the location we are in and use it
-            const now = new Date()
-            locations.forEach(loc => {
-                if (loc.arrive.toDate() < now && loc.depart.toDate() > now) {
-                    this.setState({ selectedLocation: loc })
-                }
-            });
-        }
         // Default to the first location if nothing found yet
         if (!this.state.selectedLocation) {
             this.setState({ selectedLocation: locations[0] })


### PR DESCRIPTION
Now that the trip is over, it no longer makes sense to have the site display the current country we are in.  This update will default the site to show the first location instead.